### PR TITLE
fix: stabilize public preflight gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,10 +333,7 @@ public-secret-audit:
 		echo "❌ 发现禁止跟踪的敏感文件"; \
 		exit 1; \
 	fi
-	@if rg -n --hidden -S --glob '!.git/**' --glob '!node_modules/**' --glob '!dist/**' --glob '!build/**' --glob '!*.egg-info/**' 'pypi-[A-Za-z0-9_-]{20,}|AKIA[0-9A-Z]{16}|BEGIN (RSA|OPENSSH|EC|DSA) PRIVATE KEY|SecretAccessKey\s*[:=]\s*[^<\s]+' .; then \
-		echo "❌ secret pattern audit failed"; \
-		exit 1; \
-	fi
+	@uv run --extra dev python scripts/open_source_audit.py --target public-repo
 	@echo "✅ secret audit passed"
 
 public-audit: public-secret-audit
@@ -377,7 +374,7 @@ public-build-check: clean-dist public-sync-ksadk-web-static
 	@uv run pytest tests/test_runtime_common_packaging.py::test_built_wheel_excludes_web_ui_node_modules -q
 	@uv run --extra dev python -m twine check dist/*
 
-public-preflight: public-audit public-sync-ksadk-web-static public-test public-docs-build public-build-check
+public-preflight: public-audit public-build-check public-test public-docs-build
 	@echo "✅ public preflight passed"
 
 public-publish-check:

--- a/tests/skills/test_web_artifacts_fixture.py
+++ b/tests/skills/test_web_artifacts_fixture.py
@@ -5,6 +5,8 @@ import os
 import zipfile
 from pathlib import Path
 
+import pytest
+
 
 FIXTURE = Path(
     os.environ.get("KSADK_WEB_ARTIFACTS_FIXTURE", "~/Downloads/web-artifacts-builder.zip")
@@ -13,7 +15,11 @@ EXPECTED_SHA256 = "b95f0735357fcf879bd53ed85cb242679ec74438e3bc8e85b1f27193169b6
 
 
 def test_web_artifacts_builder_zip_matches_skill_service_fixture_contract():
-    assert FIXTURE.exists(), "fixture zip should be present for local/preprod verification"
+    if not FIXTURE.exists():
+        pytest.skip(
+            "web-artifacts-builder fixture zip is only required for local/preprod verification"
+        )
+
     data = FIXTURE.read_bytes()
     assert hashlib.sha256(data).hexdigest() == EXPECTED_SHA256
 

--- a/tests/test_config_env_registry.py
+++ b/tests/test_config_env_registry.py
@@ -1,23 +1,17 @@
 from __future__ import annotations
 
-import subprocess
+import re
 from pathlib import Path
 
 from ksadk.configs.env_registry import ENV_VAR_REGISTRY
 
 
 def _source_ksadk_env_names() -> set[str]:
-    result = subprocess.run(
-        ["rg", "-o", "KSADK_[A-Z0-9_]+", "ksadk"],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    return {
-        line.rsplit(":", 1)[-1].strip()
-        for line in result.stdout.splitlines()
-        if line.strip()
-    }
+    names: set[str] = set()
+    pattern = re.compile(r"KSADK_[A-Z0-9_]+")
+    for source_path in Path("ksadk").rglob("*.py"):
+        names.update(pattern.findall(source_path.read_text(encoding="utf-8")))
+    return names
 
 
 def test_env_registry_has_unique_sorted_names():

--- a/tests/test_public_release_positioning.py
+++ b/tests/test_public_release_positioning.py
@@ -123,7 +123,7 @@ def test_pypi_publish_workflow_uses_trusted_publishing_and_bundles_ksadk_web():
     assert "KSADK_WEB_VERSION ?= latest" in makefile
     assert "PUBLIC_KSADK_WEB_VERSION ?= 0.2.11" in makefile
     assert "public-build-check: clean-dist public-sync-ksadk-web-static" in makefile
-    assert "public-preflight: public-audit public-sync-ksadk-web-static public-test" in makefile
+    assert "public-preflight: public-audit public-build-check public-test public-docs-build" in makefile
     assert "PYPI_API_TOKEN" not in workflow
     assert "password:" not in workflow
 


### PR DESCRIPTION
Public release gate fixes for 0.6.6:\n- make public secret audit CI-safe\n- reorder public-preflight for build-before-test\n- skip missing web artifact fixture outside local/preprod\n- make help snapshot and release-positioning assertions stable\n\nReady for manual review.