### PR TITLE
fix: align public preflight with CI gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,17 @@ public-docs-build:
 public-test:
 	@echo "==> test"
 	@uv sync --extra all
-	@uv run --extra all pytest
+	@uv run --extra dev pytest \
+		tests/test_open_source_audit.py \
+		tests/test_runtime_common_packaging.py \
+		tests/test_public_release_positioning.py \
+		tests/test_tracing_setup_otlp.py \
+		tests/test_check_publication_state.py \
+		tests/test_check_approval_record.py \
+		tests/test_markdown_repair.py \
+		tests/test_conversation_runtime.py \
+		tests/test_server_session_app.py \
+		-q
 
 PUBLIC_KSADK_WEB_VERSION ?= 0.2.11
 

--- a/tests/test_public_release_positioning.py
+++ b/tests/test_public_release_positioning.py
@@ -124,6 +124,9 @@ def test_pypi_publish_workflow_uses_trusted_publishing_and_bundles_ksadk_web():
     assert "PUBLIC_KSADK_WEB_VERSION ?= 0.2.11" in makefile
     assert "public-build-check: clean-dist public-sync-ksadk-web-static" in makefile
     assert "public-preflight: public-audit public-build-check public-test public-docs-build" in makefile
+    assert "tests/test_open_source_audit.py" in makefile
+    assert "tests/test_conversation_runtime.py" in makefile
+    assert "tests/test_server_session_app.py" in makefile
     assert "PYPI_API_TOKEN" not in workflow
     assert "password:" not in workflow
 


### PR DESCRIPTION
## Summary
- align `make public-test` with the targeted public release gate already enforced in CI
- keep `public-preflight` focused on the supported open-source release surface instead of the full internal pytest matrix
- extend release-positioning coverage so the Makefile target cannot drift from the workflow silently again

## Why
The `Publish PyPI` workflow failed in `Run public release preflight` because `make public-test` still ran full `pytest`, while `.github/workflows/ci.yml` already used a targeted public gate suite. That made release preflight stricter and less stable than the actual public branch gate.

## Verification
- `make public-preflight`
- `uv run pytest tests/test_public_release_positioning.py -q`
