### PR TITLE
fix(ci): publish-pypi.yml deploy-pages environment 移到 job 级

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -61,6 +61,9 @@ jobs:
   deploy-pages:
     needs: publish
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
     defaults:
       run:
         working-directory: docs-site
@@ -94,6 +97,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deploy
         uses: actions/deploy-pages@v4
-        environment:
-          name: github-pages
-          url: ${{ steps.deploy.outputs.page_url }}


### PR DESCRIPTION
## 修复

publish-pypi.yml 的 deploy-pages job 把 environment 写在 step 级(actions/deploy-pages@v4 下面),导致 workflow 解析失败:

```
HTTP 422: Invalid Argument - failed to parse workflow: (Line: 97, Col: 9): Unexpected value 'environment'
```

release published 和 workflow_dispatch 都触发不了 publish-pypi.yml,0.6.8 无法发 PyPI / 部署 GitHub Pages。

## 改动

environment 从 step 移到 deploy-pages job 级(deploy-pages 本就需要 github-pages environment 做 Pages 部署鉴权),step 只保留 uses: actions/deploy-pages@v4。

## 验证

YAML 语法校验通过。修复后 release published 可正常触发 publish + deploy-pages 两个 job。

🤖 Generated with [Claude Code](https://claude.com/claude-code)