### PR TITLE
fix(ci): publish-pypi publish job 加 setup pnpm

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -41,6 +41,11 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true


### PR DESCRIPTION
publish job 跑 public-preflight 需要 pnpm build Fumadocs,补 setup pnpm。发版阻塞修复。