### PR TITLE
fix(readme): remove unreleased candidate messaging

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -41,18 +41,6 @@ agentengine web . --no-open
 
 <p align="center"><img alt="Real local Web UI demo" src="docs-site/public/assets/ksadk-local-debugging-demo.gif" width="860" /></p>
 
-## 0.8.0 Review Candidate
-
-`0.8.0` is an in-review candidate branch, not a published PyPI or npm release. It brings RuntimeEvent, AG-UI/A2UI, A2A, Harness, and CodexRuntime into one runtime boundary while retaining the `/v1/responses` and `/v1/chat/completions` compatibility surfaces.
-
-- **Hosted UI:** AG-UI/A2UI is capability-selected; the established Responses transport remains the fallback when it is unavailable.
-- **Event diagnosis:** `ksadk replay <session-id>` reads persisted RuntimeEvent history and can narrow investigation with `--after-seq-id` / `--before-seq-id`. It never runs a model, tool, or approval side effect again.
-- **Managed A2A (experimental):** AgentEngine composes trusted ingress through its Gateway and Space-scoped outbound clients. The first external-Agent release supports only `external_public`, governed by `Network.EnablePublicAccess` and a constrained NAT transport; `external_vpc` is not yet available.
-- **Codex Managed Runtime (new):** use an `agentengine.yaml` without `agent.py` to debug Codex natively on macOS, Windows, and Linux. Direct deployment sends an inline manifest rather than a KS3 code archive; the cloud selects a pinned Linux Runtime image.
-- **Framework migration:** Prefer LangGraph, Google ADK, or the `RuntimeAdapter` contract for new integrations. Legacy LangChain continuity/HITL is not a `0.8` compatibility commitment.
-
-Read the [Codex Managed Runtime guide](https://kingsoftcloud.github.io/ksadk-python/en/docs/framework/guides/managed-runtime/), the [Hosted UI and event replay guide](https://kingsoftcloud.github.io/ksadk-python/en/docs/framework/guides/hosted-ui-events/), the [managed A2A Runtime guide](https://kingsoftcloud.github.io/ksadk-python/en/docs/framework/guides/a2a-runtime/), the [HarnessApp guide](https://kingsoftcloud.github.io/ksadk-python/en/docs/framework/guides/harness-app/), and the [0.8.0 changelog](CHANGELOG.md).
-
 ## Why KsADK
 
 Most agent frameworks solve how to build agents. KsADK solves how to run, debug, deploy, and observe them.

--- a/README.md
+++ b/README.md
@@ -41,18 +41,6 @@ agentengine web . --no-open
 
 <p align="center"><a href="https://raw.githubusercontent.com/kingsoftcloud/ksadk-python/main/docs-site/public/assets/ksadk-local-debugging-demo.gif"><img alt="KsADK 真实本地 Web UI 演示" src="https://raw.githubusercontent.com/kingsoftcloud/ksadk-python/main/docs-site/public/assets/ksadk-local-debugging-demo.gif" width="860" /></a></p>
 
-## 0.8.0 评审候选
-
-`0.8.0` 是正在评审的候选分支，不是已发布的 PyPI/npm 版本。它把 RuntimeEvent、AG-UI/A2UI、A2A、Harness 和 CodexRuntime 统一到同一运行时边界，同时保持 `/v1/responses` 和 `/v1/chat/completions` 兼容入口可用。
-
-- **Hosted UI**：AG-UI/A2UI 通过能力协商启用；不能协商时继续使用既有 Responses transport。
-- **事件诊断**：`ksadk replay <session-id>` 只读回放新 RuntimeEvent 历史，可用事件序号（`seq_id`）窗口缩小排查范围，不会再次执行模型、工具或审批副作用。
-- **托管 A2A（实验性）**：AgentEngine 通过 Gateway 装配可信入站和 Space-scoped 出站 client。首期 external Agent 仅支持 `external_public`；它受 `Network.EnablePublicAccess` 控制并使用受限 NAT transport，`external_vpc` 尚不可用。
-- **Codex Managed Runtime（新增）**：使用无 `agent.py` 的 `agentengine.yaml` 在 macOS、Windows 和 Linux 原生调试 Codex；直接部署发送内联 manifest，不上传 KS3 代码包，云端选择锁定的 Linux Runtime 镜像。
-- **框架迁移**：新接入优先使用 LangGraph、Google ADK 或 `RuntimeAdapter`。旧 LangChain 连续性 / HITL 路径不属于 `0.8` 兼容性承诺。
-
-详见[Codex Managed Runtime 指南](https://kingsoftcloud.github.io/ksadk-python/cn/docs/framework/guides/managed-runtime/)、[Hosted UI 与事件回放指南](https://kingsoftcloud.github.io/ksadk-python/cn/docs/framework/guides/hosted-ui-events/)、[托管 A2A Runtime 指南](https://kingsoftcloud.github.io/ksadk-python/cn/docs/framework/guides/a2a-runtime/)、[HarnessApp 指南](https://kingsoftcloud.github.io/ksadk-python/cn/docs/framework/guides/harness-app/)和 [0.8.0 更新日志](CHANGELOG.md)。
-
 ## 为什么需要 KsADK
 
 大多数 Agent 框架解决“如何开发 Agent”。KsADK 解决“如何运行、调试、部署和观测 Agent”。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,18 +41,6 @@ agentengine web . --no-open
 
 <p align="center"><img alt="KsADK 真实本地 Web UI 演示" src="docs-site/public/assets/ksadk-local-debugging-demo.gif" width="860" /></p>
 
-## 0.8.0 评审候选
-
-`0.8.0` 是正在评审的候选分支，不是已发布的 PyPI/npm 版本。它把 RuntimeEvent、AG-UI/A2UI、A2A、Harness 和 CodexRuntime 统一到同一运行时边界，同时保持 `/v1/responses` 和 `/v1/chat/completions` 兼容入口可用。
-
-- **Hosted UI**：AG-UI/A2UI 通过能力协商启用；不能协商时继续使用既有 Responses transport。
-- **事件诊断**：`ksadk replay <session-id>` 只读回放新 RuntimeEvent 历史，可用 `--after-seq-id` / `--before-seq-id` 缩小排查窗口，不会再次执行模型、工具或审批副作用。
-- **托管 A2A（实验性）**：AgentEngine 通过 Gateway 装配可信入站和 Space-scoped 出站 client。首期 external Agent 仅支持 `external_public`；它受 `Network.EnablePublicAccess` 控制并使用受限 NAT transport，`external_vpc` 尚不可用。
-- **Codex Managed Runtime（新增）**：使用无 `agent.py` 的 `agentengine.yaml` 在 macOS、Windows 和 Linux 原生调试 Codex；直接部署发送内联 manifest，不上传 KS3 代码包，云端选择锁定的 Linux Runtime 镜像。
-- **框架迁移**：新接入优先使用 LangGraph、Google ADK 或 `RuntimeAdapter`。旧 LangChain 连续性 / HITL 路径不属于 `0.8` 兼容性承诺。
-
-详见[Codex Managed Runtime 指南](https://kingsoftcloud.github.io/ksadk-python/cn/docs/framework/guides/managed-runtime/)、[Hosted UI 与事件回放指南](https://kingsoftcloud.github.io/ksadk-python/cn/docs/framework/guides/hosted-ui-events/)、[托管 A2A Runtime 指南](https://kingsoftcloud.github.io/ksadk-python/cn/docs/framework/guides/a2a-runtime/)、[HarnessApp 指南](https://kingsoftcloud.github.io/ksadk-python/cn/docs/framework/guides/harness-app/)和 [0.8.0 更新日志](CHANGELOG.md)。
-
 ## 为什么需要 KsADK
 
 大多数 Agent 框架解决“如何开发 Agent”。KsADK 解决“如何运行、调试、部署和观测 Agent”。

--- a/tests/test_public_release_positioning.py
+++ b/tests/test_public_release_positioning.py
@@ -18,9 +18,6 @@ ZH_DOC_URLS = {
     f"{DOCS_ROOT_URL}cn/docs/framework/guides/observability-tracing/",
     f"{DOCS_ROOT_URL}cn/docs/framework/guides/cloud-deployment/",
     f"{DOCS_ROOT_URL}cn/docs/framework/guides/hosted-ui-events/",
-    f"{DOCS_ROOT_URL}cn/docs/framework/guides/a2a-runtime/",
-    f"{DOCS_ROOT_URL}cn/docs/framework/guides/managed-runtime/",
-    f"{DOCS_ROOT_URL}cn/docs/framework/guides/harness-app/",
 }
 EN_DOC_URLS = {
     f"{DOCS_ROOT_URL}en/docs/framework/getting-started/quickstart/",
@@ -30,9 +27,6 @@ EN_DOC_URLS = {
     f"{DOCS_ROOT_URL}en/docs/framework/guides/observability-tracing/",
     f"{DOCS_ROOT_URL}en/docs/framework/guides/cloud-deployment/",
     f"{DOCS_ROOT_URL}en/docs/framework/guides/hosted-ui-events/",
-    f"{DOCS_ROOT_URL}en/docs/framework/guides/a2a-runtime/",
-    f"{DOCS_ROOT_URL}en/docs/framework/guides/managed-runtime/",
-    f"{DOCS_ROOT_URL}en/docs/framework/guides/harness-app/",
 }
 
 _DOCS_LINK_PATTERN = re.compile(
@@ -105,6 +99,8 @@ def test_public_readme_positions_ksadk_as_runtime_platform():
     assert "当前版本：" not in readme
     assert "发布版本：" not in readme
     assert "## 0.6." not in readme
+    assert "0.8.0" not in readme
+    assert "评审候选" not in readme
 
 
 def test_public_readme_language_variants_keep_homepage_shape():
@@ -120,6 +116,8 @@ def test_public_readme_language_variants_keep_homepage_shape():
         assert "ksadk-runtime-architecture.png" in text
         assert "发布版本：" not in text
         assert "## 0.6." not in text
+        assert "0.8.0" not in text
+        assert "评审候选" not in text
 
     assert "Kingsoft Cloud Agent Development Kit" in en_readme
     assert "ksadk-runtime-platform-hero-wide.png" in en_readme
@@ -129,6 +127,8 @@ def test_public_readme_language_variants_keep_homepage_shape():
     assert "ksadk-runtime-architecture.png" not in en_readme
     assert "发布版本：" not in en_readme
     assert "## 0.6." not in en_readme
+    assert "0.8.0" not in en_readme
+    assert "Review Candidate" not in en_readme
 
     assert _github_pages_urls(root_readme) == {DOCS_ROOT_URL, *ZH_DOC_URLS}
     assert _github_pages_urls(zh_readme) == {DOCS_ROOT_URL, *ZH_DOC_URLS}


### PR DESCRIPTION
Removes the unreleased 0.8 review-candidate section from all public README variants and adds a regression guard.\n\nValidation: ==> release version gate (prevent downgrade/re-publish)
uv run python scripts/check_release_version.py
==> 版本门禁:本地 ksadk=0.8.0
✅ ksadk: 本地版本 0.8.0 > PyPI 已发版本 0.7.0
✅ agentengine-sdk-python: 本地版本 0.8.0 > PyPI 已发版本 0.7.0
✅ 版本门禁通过:本地版本 0.8.0 高于所有已发版本
==> secret and sensitive-file audit
✅ secret audit passed
==> public source audit
target: public-repo
checked: 1128
violations: 0
✅ public path audit passed
Sync KsADK Web static assets from @kingsoftcloud/ksadk-web@0.3.0
Using cached tarball kingsoftcloud-ksadk-web-0.3.0.tgz
tar -xzf ".cache/ksadk-web/$(cat ".cache/ksadk-web/.tarball-name")" -C ".cache/ksadk-web"
cp -R ".cache/ksadk-web/package/dist-ksadk/." "ksadk/server/static/"
Verified KsADK Web 0.3.0 static payload: 251 files, sha256=2ed4045a00a2ff9e92145cc0bd647e318dea1ff2f2a86aab3db183f9a1218011
Synced KsADK Web 0.3.0 static assets into ksadk/server/static
==> test
============================= test session starts ==============================
platform darwin -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /private/tmp/ksadk-python-public-0.8.0-1785310789004
configfile: pyproject.toml
plugins: anyio-4.12.1, asyncio-1.3.0, langsmith-0.8.5
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 45 items

tests/test_public_release_positioning.py ...............                 [ 33%]
tests/test_config_env_registry.py .....                                  [ 44%]
tests/test_managed_runtime_builder.py ........                           [ 62%]
tests/test_managed_runtime_resolution.py ......                          [ 75%]
tests/cli/test_cmd_create_codex.py ......                                [ 88%]
tests/runners/test_codex_runner.py .....                                 [100%]

============================== 45 passed in 1.10s ==============================
==> docs-site (Fumadocs) build
Lockfile is up to date, resolution step is skipped
Already up to date


> ksadk-docs-scaffold@0.0.0 postinstall /private/tmp/ksadk-python-public-0.8.0-1785310789004/docs-site
> fumadocs-mdx

[MDX] generated files in 18.113166999999976ms
╭ Warning ─────────────────────────────────────────────────────────────────────╮
│                                                                              │
│   Ignored build scripts: esbuild@0.28.1, sharp@0.34.5.                       │
│   Run "pnpm approve-builds" to pick which dependencies should be allowed     │
│   to run scripts.                                                            │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
Done in 1.5s using pnpm v10.33.2

> ksadk-docs-scaffold@0.0.0 build:static /private/tmp/ksadk-python-public-0.8.0-1785310789004/docs-site
> node scripts/build-static.mjs

▲ Next.js 16.2.6 (Turbopack)

[MDX] generated files in 359.8837500000001ms
  Creating an optimized production build ...
✓ Compiled successfully in 21.9s
  Running TypeScript ...
  Finished TypeScript in 4.2s ...
  Collecting page data using 10 workers ...
  Generating static pages using 10 workers (0/193) ...
  Generating static pages using 10 workers (48/193) 
  Generating static pages using 10 workers (96/193) 
  Generating static pages using 10 workers (144/193) 
✓ Generating static pages using 10 workers (193/193) in 4.1s
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ● /[lang]
│ ├ /cn
│ └ /en
├ ● /[lang]/docs/[[...slug]]
│ ├ /cn/docs/cli
│ ├ /cn/docs/framework
│ ├ /cn/docs/references/environment-variables
│ └ [+89 more paths]
├ ○ /api/search
├ ○ /llms-full.txt
├ ● /llms.mdx/docs/[[...slug]]
│ ├ /llms.mdx/docs/cli/content.md
│ ├ /llms.mdx/docs/framework/content.md
│ ├ /llms.mdx/docs/references/environment-variables/content.md
│ └ [+43 more paths]
├ ○ /llms.txt
└ ● /og/docs/[...slug]
  ├ /og/docs/cli/image.png
  ├ /og/docs/framework/image.png
  ├ /og/docs/references/environment-variables/image.png
  └ [+43 more paths]


○  (Static)  prerendered as static content
●  (SSG)     prerendered as static HTML (uses generateStaticParams)

[build:static] wrote out/.nojekyll
🧹 清理 dist/build 临时产物...
==> build and twine check
Verified KsADK Web 0.3.0 static payload: 251 files, sha256=2ed4045a00a2ff9e92145cc0bd647e318dea1ff2f2a86aab3db183f9a1218011
.................                                                        [100%]
17 passed in 0.30s
Checking dist/ksadk-0.8.0-py3-none-any.whl: PASSED
Checking dist/ksadk-0.8.0.tar.gz: PASSED
==> audit wheel and sdist file lists
target: wheel
checked: 578
violations: 0
target: sdist
checked: 649
violations: 0
✅ public preflight passed (45 release-gate tests, docs build, wheel/sdist and secret audits).