### PR TITLE
fix: _build_state_delta 白名单增加 metadata, 让父 Agent 通过 A2A 注入的自定义参数透传到子 …

### DIFF
--- a/ksadk/runners/adk_runner.py
+++ b/ksadk/runners/adk_runner.py
@@ -1255,6 +1255,7 @@ class ADKRunner(BaseRunner):
             "current_attachments",
             "current_attachment_results",
             "has_current_files",
+            "metadata",
         ):
             if key in input_data:
                 state_delta[key] = input_data.get(key)

--- a/tests/runners/test_adk_runner.py
+++ b/tests/runners/test_adk_runner.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from a2a.server.agent_execution import RequestContext
+from a2a.server.agent_execution.context import ServerCallContext
+from a2a.types import SendMessageRequest
+from google.protobuf.json_format import ParseDict
+
+from ksadk.a2a.executor import A2ARuntimeExecutor
+from ksadk.runners.adk_runner import ADKRunner
+
+
+def _build_request_context(metadata: dict | None = None) -> RequestContext:
+    payload: dict = {
+        "message": {
+            "messageId": "msg-1",
+            "role": "ROLE_USER",
+            "parts": [{"text": "你好"}],
+            "taskId": "task-1",
+            "contextId": "ctx-1",
+        },
+    }
+    if metadata is not None:
+        payload["metadata"] = metadata
+    params = ParseDict(payload, SendMessageRequest())
+    call_context = ServerCallContext(state={})
+    return RequestContext(call_context=call_context, request=params)
+
+
+def test_metadata_flows_from_a2a_to_state_delta():
+    """父 Agent 通过 A2A metadata 注入的自定义参数应能在子 Agent 的 tool_context.state 中读取。"""
+    ctx = _build_request_context(metadata={"real_user_id": "user-123"})
+    executor = A2ARuntimeExecutor(runner=ADKRunner.__new__(ADKRunner))
+    runner = ADKRunner.__new__(ADKRunner)
+
+    # A2A 层: context.metadata → runner_input
+    runner_input = executor._build_runner_input(ctx)  # noqa: SLF001
+    assert runner_input["metadata"] == {"real_user_id": "user-123"}
+
+    # ADK 层: runner_input → state_delta（修复前 metadata 被丢弃）
+    state_delta = runner._build_state_delta(runner_input)  # noqa: SLF001
+    assert state_delta["metadata"] == {"real_user_id": "user-123"}
+
+    # 白名单行为: 已白名单字段透传, 无关字段过滤
+    raw = {"input_parts": ["p1"], "metadata": {"k": "v"}, "unknown": "x"}
+    sd = runner._build_state_delta(raw)  # noqa: SLF001
+    assert sd == {"input_parts": ["p1"], "metadata": {"k": "v"}}


### PR DESCRIPTION
…Agent 的 tool_context.state

## Summary

-

## Validation

- [ ] `uv run --extra dev pytest -q`
- [ ] `make public-audit`
- [ ] `make docs-site-build`
- [ ] `make open-source-audit-dist` if package artifacts changed.
- [ ] `uv build`
- [ ] `uv run --extra dev python -m twine check dist/*`

## Public Surface

- [ ] README or public docs updated if user-facing behavior changed.
- [ ] Package metadata, extras, or release artifacts reviewed if packaging changed.
- [ ] GitHub Pages impact reviewed if docs changed.

## Security impact

- [ ] No tokens, credentials, private URLs, customer data, internal deployment notes, or `.zread/` output are introduced.
- [ ] Security-sensitive changes are described without exploit details.

## Release

- [ ] Release notes impact is documented.
- [ ] Maintainer review is required before public release or publish actions.
- [ ] Branch protection and `pypi` environment protection stay enabled for publishable changes.
