### PR TITLE
fix(langgraph): filter plain-text tool_call markers from model history

### DIFF
--- a/ksadk/runners/langgraph_runner.py
+++ b/ksadk/runners/langgraph_runner.py
@@ -378,6 +378,9 @@ class LangGraphRunner(BaseRunner):
             for msg in history:
                 role = msg.get("role")
                 content = msg.get("content", "")
+                # 跳过纯文本格式的 tool_call/tool_result，避免模型学到错误格式
+                if isinstance(content, str) and content.startswith(("[tool_call]", "[tool_result]", "[approval_request]", "[approval_response]")):
+                    continue
                 if role == "user":
                     messages.append(HumanMessage(content=content))
                 elif role in ("assistant", "model"):
@@ -1239,9 +1242,13 @@ class LangGraphRunner(BaseRunner):
             yield {"type": "checkpoint", "metadata": metadata}
 
     def _filter_tool_tags(self, content: str) -> str:
-        """过滤 <tool_call> 标签"""
+        """过滤 tool_call 标签（支持尖括号和方括号格式）"""
         if not isinstance(content, str):
             return content
+        # 过滤 <tool_call>...</tool_call>
         content = re.sub(r"<tool_call>.*?</tool_call>", "", content, flags=re.DOTALL)
         content = re.sub(r"</?(?:tool_call|arg_key|arg_value)>", "", content)
+        # 过滤 [tool_call]... 和 [tool_result]... 格式（整行或到下一个标记前）
+        content = re.sub(r"\[tool_call\]\[?.*?($|\[tool_result\]|\[approval)", "", content, flags=re.DOTALL)
+        content = re.sub(r"\[tool_result\]\[?.*?($|\[tool_call\]|\[approval)", "", content, flags=re.DOTALL)
         return content


### PR DESCRIPTION

  ## 问题描述
  当使用 LangChain/LangGraph 框架时，模型偶尔会输出 `[tool_call] xxx` 纯文本格式，而不是正确的 Function Calling 结构化调用。这导致工具无法执行，用户体验受损。
<img width="1246" height="1152" alt="image" src="https://github.com/user-attachments/assets/a2d23bd1-b209-441d-b793-cda2717ccc47" />

  ## 根因分析
  `context.py` 在构建对话历史时，将结构化的 `tool_call`/`tool_result` 事件拍平为带 `[tool_call]` 前缀的纯文本格式：
  
  text = f"[tool_call] {text}"

  当这些带前缀的消息通过 history 传入 LangGraph Runner 时，模型从历史中学习到了错误的输出格式，直接模仿输出 [tool_call] xxx 纯文本，而非触发真正的工具调用。

  复现步骤

  1. 创建 LangChain Agent（使用 create_agent）
  2. 进行多轮对话，触发工具调用
  3. 在后续对话中，模型偶现输出 [tool_call] get_xxx 纯文本而不是执行工具

  修复方案

  方案选择

  采用消费端过滤方案（而非修改 context.py 的生成逻辑），原因：
  - context.py 的格式可能用于其他 Runner（如远程 Runner、UI 展示）
  - 仅影响 LangChain/LangGraph Runner，不影响其他组件

  改动内容

  1. 过滤历史消息（langgraph_runner.py _to_state 方法）
    - 跳过 [tool_call]/[tool_result]/[approval_request]/[approval_response] 格式的纯文本消息
    - 防止模型从历史中学到错误格式
  2. 兜底过滤输出（langgraph_runner.py _filter_tool_tags 方法）
    - 增加对方括号格式 [tool_call] 的过滤
    - 防止模型错误输出污染最终结果

  测试

  - [x] 多轮对话后，模型不再输出 [tool_call] 纯文本
  - [x] 工具调用正常触发
  - [x] 历史记录正确传递（非 tool 相关消息不受影响）