### PR TITLE
ci(publish): install chromium for phase 2 browser gates

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Sync KsADK Web static assets
         run: make sync-ksadk-web-static
 
+      - name: Install Chromium for Phase 2 browser gates
+        run: uv run playwright install --with-deps chromium
+
       - name: Run public release preflight
         if: env.PUBLISH_TARGET == 'full'
         run: make public-preflight


### PR DESCRIPTION
## Summary

The PyPI publish workflow runs `make public-preflight`, which includes the Phase 2 browser gates. 0.8.3 added DSH client bundle / scheduler browser gates, so the publish workflow now needs Playwright chromium — the same requirement `release-check.yml` already satisfies with its `Install Chromium for Phase 2 browser gates` step.

Without this, the 0.8.3 publish run fails with:
```
playwright._impl._errors.Error: BrowserType.launch: Executable doesn't exist at .../chrome-headless-shell
```

Add the matching install step before the preflight so the PyPI publish workflow can complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)