### PR TITLE
ci(publish): uv sync before playwright install

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -67,7 +67,9 @@ jobs:
         run: make sync-ksadk-web-static
 
       - name: Install Chromium for Phase 2 browser gates
-        run: uv run playwright install --with-deps chromium
+        run: |
+          uv sync --extra all
+          uv run playwright install --with-deps chromium
 
       - name: Run public release preflight
         if: env.PUBLISH_TARGET == 'full'


### PR DESCRIPTION
Follow-up to #57. The publish job has no Install dependencies step, so `uv run playwright install` could not find the playwright binary. Run `uv sync --extra all` first (matching release-check) then install chromium so the Phase 2 browser gates have both the package and the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)