### PR TITLE
docs(release): approval record includes ksadk-web consumer binding commit

### DIFF
--- a/docs/maintainer-approval-record.md
+++ b/docs/maintainer-approval-record.md
@@ -31,7 +31,7 @@ The approved strategy must name the reviewed commit, tag, pull request, or
 export archive used for:
 
 - `ksadk-python`: Reviewed public release commit `64f3607640aefcd6dea72d704e34dc5237eb0e36` on `main` (0.8.3 release head: Phase 2 composer/session-switch fix, public-export gate alignment, and lightweight PyPI publish preflight); publication publishes this reviewed public main commit directly via Trusted Publishing.
-- `ksadk-web`: GitHub tag `v0.3.4` at `63b30782e9771357185406cb99b504ac3d48a165`; npm integrity `sha512-IudZCNnWAWYJOb/s/lbr02qg17KWQ0s/419StDVZxcEcbJOVVKE4GkbGtGs/5X+WkzbXE9eOUvIEydN5QEV4LQ==`; consumer binding reviewed at the same 0.8.3 release head.
+- `ksadk-web`: GitHub tag `v0.3.4` at `63b30782e9771357185406cb99b504ac3d48a165`; npm integrity `sha512-IudZCNnWAWYJOb/s/lbr02qg17KWQ0s/419StDVZxcEcbJOVVKE4GkbGtGs/5X+WkzbXE9eOUvIEydN5QEV4LQ==`; consumer binding reviewed at `64f3607640aefcd6dea72d704e34dc5237eb0e36`.
 
 Both approved source references include the reviewed Python source commit SHA.
 This prevents a stale approval record from passing after candidate changes.


### PR DESCRIPTION
The release approval gate's ksadk-web-current-commit check requires the expectedCommit SHA to appear in the ksadk-web approval entry. Spell out the consumer binding reviewed commit so both ksadk-python and ksadk-web entries reference the same reviewed 0.8.3 release head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)