### PR TITLE
style(studio): align web UI with King Design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,8 @@ webui
 ksadk/server/static/**
 # Generated from the tracked React Studio source during release/build.
 ksadk/studio/static/**
+# Reviewable visual layer for the public Studio static distribution.
+!ksadk/studio/static/studio-refinement.css
 # Generated immediately before packaging and embedded in wheel/sdist.  Release
 # gates verify it against the checked-out source commit; it is never source.
 ksadk/_build_provenance.json

--- a/ksadk/studio/static/index.html
+++ b/ksadk/studio/static/index.html
@@ -8,6 +8,7 @@
     <link rel="modulepreload" crossorigin href="/static/assets/rolldown-runtime-hePW80VL.js">
     <link rel="modulepreload" crossorigin href="/static/assets/react-vendor-BNmTiJ-I.js">
     <link rel="stylesheet" crossorigin href="/static/assets/index-DXs1Eq4M.css">
+    <link rel="stylesheet" href="/static/studio-refinement.css">
   </head>
   <body>
     <div id="root"></div>

--- a/ksadk/studio/static/studio-refinement.css
+++ b/ksadk/studio/static/studio-refinement.css
@@ -270,13 +270,22 @@ input, textarea, select, .studio-select-trigger, .studio-multi-select-trigger,
   outline-offset: 3px;
 }
 :is(input, textarea, select):focus,
-.studio-select-trigger:focus-visible,
-.studio-select-trigger[data-state="open"],
-.studio-multi-select-trigger[aria-expanded="true"],
 .search-field:focus-within {
   outline: 2px solid var(--accent-border);
   outline-offset: 1px;
   border-color: var(--accent);
+}
+/* Opening with a pointer needs a border, not a second focus frame. */
+.studio-select-trigger[data-state="open"],
+.studio-multi-select-trigger[aria-expanded="true"] {
+  border-color: var(--accent);
+  outline: none;
+}
+.studio-select-trigger:focus-visible,
+.studio-multi-select-trigger:focus-visible {
+  border-color: var(--accent);
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
 }
 .search-field input:focus { outline: none; }
 input::placeholder, textarea::placeholder { color: var(--text-tertiary); opacity: 1; }
@@ -300,6 +309,39 @@ input::placeholder, textarea::placeholder { color: var(--text-tertiary); opacity
 .chat-approval-menu {
   border-color: var(--border);
   border-radius: var(--radius-surface);
+}
+/* Keep selected and hovered rows visibly separate across shared menus. */
+.studio-select-content {
+  min-width: min(176px, calc(100vw - 24px));
+  max-width: calc(100vw - 24px);
+  padding: 4px;
+}
+.studio-select-viewport { padding: 6px; }
+.more-actions-menu, .composer-action-menu, .composer-command-menu,
+.chat-model-menu, .chat-approval-menu { padding: 10px; }
+.studio-command-list { padding: 10px; }
+.studio-select-item {
+  min-height: 40px;
+  border-radius: var(--radius-control);
+  padding: 8px 34px 8px 12px;
+}
+.more-actions-item, .chat-model-option {
+  min-height: 40px;
+  padding-inline: 12px;
+}
+.studio-select-item + .studio-select-item,
+.more-actions-item + .more-actions-item,
+.composer-action-item + .composer-action-item,
+.chat-model-option + .chat-model-option,
+.chat-approval-option + .chat-approval-option,
+.studio-command-list [cmdk-item] + [cmdk-item],
+.composer-command-menu [cmdk-item] + [cmdk-item] { margin-top: 6px; }
+.composer-command-menu [cmdk-list] { gap: 0; }
+.studio-select-item:focus-visible, .more-actions-item:focus-visible,
+.composer-action-item:focus-visible, .chat-model-option:focus-visible,
+.chat-approval-option:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }
 .studio-dialog, .overlay .drawer {
   border-color: var(--border);

--- a/ksadk/studio/static/studio-refinement.css
+++ b/ksadk/studio/static/studio-refinement.css
@@ -277,11 +277,6 @@ input, textarea, select, .studio-select-trigger, .studio-multi-select-trigger,
   background: var(--surface);
   outline: none;
 }
-.studio-select-trigger:hover:not(:disabled),
-.studio-multi-select-trigger:hover:not(:disabled) {
-  background: var(--surface);
-  border-color: var(--brand);
-}
 .app-shell :is(button, a, [role="tab"], [role="combobox"]):focus-visible,
 .overlay :is(button, a, [role="tab"], [role="combobox"]):focus-visible {
   outline: 2px solid var(--focus-ring);
@@ -293,17 +288,22 @@ input, textarea, select, .studio-select-trigger, .studio-multi-select-trigger,
   outline-offset: 1px;
   border-color: var(--accent);
 }
-/* Opening with a pointer needs a border, not a second focus frame. */
+/* Selection controls use a background change instead of an accent frame. */
+.studio-select-trigger:hover:not(:disabled),
+.studio-multi-select-trigger:hover:not(:disabled),
 .studio-select-trigger[data-state="open"],
-.studio-multi-select-trigger[aria-expanded="true"] {
-  border-color: var(--accent);
+.studio-multi-select-trigger[aria-expanded="true"],
+select:hover:not(:disabled), select:focus {
+  background: var(--surface-hover);
+  border-color: var(--border-strong);
   outline: none;
 }
 .studio-select-trigger:focus-visible,
-.studio-multi-select-trigger:focus-visible {
-  border-color: var(--accent);
-  outline: 2px solid var(--focus-ring);
-  outline-offset: 3px;
+.studio-multi-select-trigger:focus-visible,
+:is(.app-shell, .overlay) :is(.studio-select-trigger, .studio-multi-select-trigger):focus-visible {
+  background: var(--accent-soft);
+  border-color: var(--border-strong);
+  outline: none;
 }
 .search-field input:focus { outline: none; }
 input::placeholder, textarea::placeholder { color: var(--text-tertiary); opacity: 1; }
@@ -403,8 +403,7 @@ input::placeholder, textarea::placeholder { color: var(--text-tertiary); opacity
 .studio-select-item:focus-visible, .more-actions-item:focus-visible,
 .composer-action-item:focus-visible, .chat-model-option:focus-visible,
 .chat-approval-option:focus-visible {
-  outline: 2px solid var(--focus-ring);
-  outline-offset: -2px;
+  outline: none;
 }
 .studio-dialog, .overlay .drawer {
   border-color: var(--border);

--- a/ksadk/studio/static/studio-refinement.css
+++ b/ksadk/studio/static/studio-refinement.css
@@ -1,0 +1,524 @@
+/*
+ * Studio visual refinement for the public static distribution.
+ * Load after the compiled stylesheet. Keep behavior and responsive layout in
+ * the original bundle; this file owns the visual tokens and component finish.
+ * Migrate these styles into the source theme before replacing the bundle.
+ */
+
+/* Theme tokens, including aliases used by the compiled conversation UI. */
+:root {
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC",
+    "Noto Sans CJK SC", "Microsoft YaHei UI", sans-serif;
+  --font-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  --radius-control: 8px;
+  --radius-small: 6px;
+  --radius-surface: 12px;
+  --radius-block: 12px;
+  --radius-card: 12px;
+  --radius-inset: 8px;
+  --radius-chip: 6px;
+  --radius-rail: 8px;
+  --control-height: 40px;
+  --button-height: 36px;
+  --button-height-small: 32px;
+}
+
+:root:not(.dark) {
+  --canvas: #faf9f6;
+  --sidebar: #f2f1ed;
+  --surface: #ffffff;
+  --surface-raised: #ffffff;
+  --surface-subtle: #f3f2ee;
+  --surface-sunken: #f6f5f1;
+  --surface-hover: #eeede7;
+  --hover: #eeede7;
+  --selected: #e7e8e0;
+  --text: #242622;
+  --text-primary: #242622;
+  --text-label: #41453b;
+  --text-secondary: #60635b;
+  --text-tertiary: #686d61;
+  --text-faint: #6b7064;
+  --text-disabled: #8a8d84;
+  --border: #e7e7df;
+  --border-card: #dedfd6;
+  --border-strong: #c9ccc1;
+  --accent: #505d43;
+  --accent-strong: #35432b;
+  --accent-soft: #eef0e8;
+  --accent-hover: #e5e9dc;
+  --accent-active: #dbe1d0;
+  --accent-border: #bfc8b1;
+  --button-primary-bg: #30342c;
+  --button-primary-bg-hover: #454d3c;
+  --button-primary-bg-active: #22271e;
+  --button-primary-text: #ffffff;
+  --success: #347354;
+  --success-soft: #edf5ee;
+  --info: #456982;
+  --info-soft: #eff4f7;
+  --warning: #8a631e;
+  --warning-text: #765214;
+  --warning-soft: #fbf4e5;
+  --danger: #b23e35;
+  --danger-soft: #fdf0ed;
+  --edge: var(--success);
+  --edge-soft: var(--success-soft);
+  --edge-border: #c9dfd0;
+  --cloud: var(--info);
+  --cloud-soft: var(--info-soft);
+  --cloud-border: #d0dce5;
+  --route: var(--warning);
+  --route-soft: var(--warning-soft);
+  --code-bg: #f5f5f0;
+  --code-text: #353b31;
+  --code-token-comment: #707667;
+  --shadow-overlay: 0 16px 48px #2426221c, 0 2px 8px #2426220a;
+  --shadow-focus: 0 0 0 3px #505d4326;
+  --shadow-focus-subtle: 0 0 0 3px #505d4318;
+  --shadow-control: 0 1px 2px #24262208;
+  --shadow-toast: 0 8px 28px #2426221a;
+}
+
+:root.dark {
+  --canvas: #1b1c1b;
+  --sidebar: #171817;
+  --surface: #222322;
+  --surface-raised: #292b28;
+  --surface-subtle: #2b2c2a;
+  --surface-sunken: #1e201d;
+  --surface-hover: #33362f;
+  --hover: #33362f;
+  --selected: #383d31;
+  --text: #eeefeb;
+  --text-primary: #eeefeb;
+  --text-label: #daddd3;
+  --text-secondary: #bec1b7;
+  --text-tertiary: #a0a598;
+  --text-faint: #92998a;
+  --text-disabled: #73796c;
+  --border: #363932;
+  --border-card: #3b3f35;
+  --border-strong: #545b4b;
+  --accent: #b8c7a5;
+  --accent-strong: #d2dfc1;
+  --accent-soft: #30372a;
+  --accent-hover: #3a4432;
+  --accent-active: #46523d;
+  --accent-border: #596b47;
+  --button-primary-bg: #e3e6dc;
+  --button-primary-bg-hover: #f2f4eb;
+  --button-primary-bg-active: #ccd4c0;
+  --button-primary-text: #242b1e;
+  --success: #95c5a2;
+  --success-soft: #26392b;
+  --info: #a6bed0;
+  --info-soft: #29353d;
+  --warning: #dfbb78;
+  --warning-text: #ecd099;
+  --warning-soft: #3c3323;
+  --danger: #e7a096;
+  --danger-soft: #432c28;
+  --edge: var(--success);
+  --edge-soft: var(--success-soft);
+  --edge-border: #425a44;
+  --cloud: var(--info);
+  --cloud-soft: var(--info-soft);
+  --cloud-border: #475b68;
+  --route: var(--warning);
+  --route-soft: var(--warning-soft);
+  --code-bg: #1d201b;
+  --code-text: #e0e4d8;
+  --code-token-comment: #9ba68e;
+  --shadow-overlay: 0 16px 48px #0000004d, 0 2px 8px #00000026;
+  --shadow-focus: 0 0 0 3px #b8c7a52e;
+  --shadow-focus-subtle: 0 0 0 3px #b8c7a51a;
+  --shadow-control: 0 1px 2px #00000026;
+  --shadow-toast: 0 8px 28px #00000040;
+}
+
+:root:not(.dark), :root.dark {
+  --rail-divider: var(--border);
+  --success-deep: var(--success);
+  --warning-deep: var(--warning-text);
+  --danger-deep: var(--danger);
+  --kc-accent-border: var(--accent-border);
+  --kc-accent-fill: var(--accent-soft);
+  --kc-accent-fill-strong: var(--surface-subtle);
+  --kc-user-bubble: var(--surface-subtle);
+  --kc-user-bubble-border: transparent;
+  --kc-think-border: var(--border);
+  --kc-think-fill: var(--surface-sunken);
+  --kc-think-hover: var(--surface-hover);
+  --kc-think-divider: var(--border);
+  --kc-code-fill: var(--code-bg);
+  --kc-composer-border: var(--border-strong);
+  --kc-graph-fill: var(--surface-sunken);
+  --kc-graph-dot: var(--border-strong);
+  --kc-node-border: var(--border-strong);
+  --kc-edge: var(--text-tertiary);
+  --kc-rail-fill: var(--canvas);
+}
+
+/* Quiet navigation with a consistent selected state. */
+.navigation-rail .product {
+  border-bottom-color: transparent;
+  padding-inline: 10px;
+}
+.navigation-rail .product-mark {
+  color: var(--button-primary-text);
+  background: var(--button-primary-bg);
+  border-color: transparent;
+  border-radius: 9px;
+  box-shadow: none;
+}
+.navigation-rail .product-copy { gap: 3px; }
+.navigation-rail .product-copy strong { letter-spacing: -0.4px; }
+.navigation-rail .product-copy span { color: var(--text-tertiary); }
+.navigation-rail .workspace-switcher {
+  background: transparent;
+  border-color: var(--border);
+  border-radius: var(--radius-control);
+  box-shadow: none;
+  margin-block: 8px 16px;
+}
+.navigation-rail .workspace-switcher:hover {
+  border-color: var(--border-strong);
+  background: var(--surface-subtle);
+}
+.navigation-rail .workspace-mark {
+  color: var(--text-secondary);
+  background: transparent;
+}
+.navigation-rail .nav-label {
+  color: var(--text-tertiary);
+  font-size: var(--font-size-caption);
+  padding-inline: 10px;
+  margin-bottom: 6px;
+}
+.navigation-rail .nav-group + .nav-group { margin-top: 20px; }
+.navigation-rail .nav-item {
+  min-height: 36px;
+  border-radius: var(--radius-control);
+  margin-block: 2px;
+  font-size: var(--font-size-meta);
+}
+.navigation-rail .nav-item svg { stroke-width: 1.7; }
+.navigation-rail .nav-item.active {
+  color: var(--text-primary);
+  background: var(--selected);
+  font-weight: var(--font-weight-semibold);
+}
+.navigation-rail .nav-item.active svg { color: var(--text-primary); }
+.navigation-rail .nav-item.active::before { content: none; }
+.navigation-rail .sidebar-footer,
+:root.dark .navigation-rail .sidebar-footer {
+  background: var(--sidebar);
+  border-top-color: var(--border);
+}
+.navigation-rail .user-avatar {
+  background: var(--surface);
+  border-color: var(--border);
+  border-radius: var(--radius-control);
+}
+.global-header,
+:root.dark .global-header {
+  background: var(--canvas);
+  border-bottom-color: var(--border);
+  backdrop-filter: none;
+}
+.global-header .header-identity { gap: 4px; }
+.global-header .header-identity > span { font-size: var(--font-size-caption); }
+.global-header .icon-button,
+.global-header .crumb {
+  border-color: transparent;
+  background: transparent;
+}
+
+/* One component vocabulary across lists, forms, settings, and popovers. */
+.button, .icon-button, .primary-button,
+input, textarea, select, .studio-select-trigger, .studio-multi-select-trigger,
+.search-field, .segmented-control, .page-tabs {
+  border-radius: var(--radius-control);
+}
+.button, .icon-button { font-size: var(--font-size-meta); }
+.button.accent, .primary-button { border-radius: var(--radius-control); }
+.button.secondary, .icon-button.secondary,
+.button:not(.accent):not(.tertiary) { border-color: var(--border-strong); }
+.button:not(.accent):not(.tertiary):hover:not(:disabled),
+.button.secondary:hover:not(:disabled),
+.icon-button.secondary:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  color: var(--text);
+  background: var(--surface-hover);
+}
+/* The public bundle's generic button rule also matches destructive actions. */
+.button.danger, .button.subtle-danger {
+  color: var(--danger);
+  background: var(--danger-soft);
+  border-color: color-mix(in srgb, var(--danger) 28%, var(--border));
+}
+.button.danger:hover:not(:disabled), .button.subtle-danger:hover:not(:disabled) {
+  color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 12%, var(--surface));
+  border-color: var(--danger);
+}
+.button:disabled, .icon-button:disabled { opacity: 0.55; }
+.app-shell :is(button, a, [role="tab"], [role="combobox"]):focus-visible,
+.overlay :is(button, a, [role="tab"], [role="combobox"]):focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+:is(input, textarea, select):focus,
+.studio-select-trigger:focus-visible,
+.studio-select-trigger[data-state="open"],
+.studio-multi-select-trigger[aria-expanded="true"],
+.search-field:focus-within {
+  outline: 2px solid var(--accent-border);
+  outline-offset: 1px;
+  border-color: var(--accent);
+}
+.search-field input:focus { outline: none; }
+input::placeholder, textarea::placeholder { color: var(--text-tertiary); opacity: 1; }
+.page-tabs, .segmented-control { background: var(--surface-subtle); }
+.page-tabs button, .segmented-control button { border-radius: 6px; }
+.page-tabs button.active, .page-tabs button[aria-selected="true"],
+.segmented-control button.selected, .segmented-control button[aria-selected="true"] {
+  border-color: var(--border);
+  background: var(--surface);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-control);
+}
+:is(.block:not(.runtime-resource-group), .table-section, .trace-list-page,
+  .agent-editor, .authoring-inspection-card, .orchestration-canvas,
+  .orchestration-aside, .trace-run-panel, .trace-span-panel, .trace-detail-panel) {
+  border-radius: var(--radius-surface);
+  box-shadow: none;
+}
+.studio-select-content, .studio-multi-select-popover, .more-actions-menu,
+.composer-action-menu, .composer-command-menu, .chat-model-menu,
+.chat-approval-menu {
+  border-color: var(--border);
+  border-radius: var(--radius-surface);
+}
+.studio-dialog, .overlay .drawer {
+  border-color: var(--border);
+  border-radius: 16px;
+  box-shadow: var(--shadow-overlay) !important;
+}
+.appearance-option { border-radius: var(--radius-control); }
+
+/* Lists: compact headings, independent filters, a single outer boundary. */
+.stat-strip.compact-summary {
+  background: transparent;
+  border-top: 0;
+  border-bottom: 1px solid var(--border);
+  padding-block: 4px 16px;
+}
+.stat-strip.compact-summary > * { background: transparent; }
+.stat-strip.compact-summary strong { font-variant-numeric: tabular-nums; }
+.agents-catalog-section { padding: 0; }
+.agents-catalog-header { min-height: 64px; padding: 20px 24px 12px; }
+.agents-catalog-section .section-toolbar {
+  background: transparent;
+  border: 0;
+  padding: 4px 24px 20px;
+  gap: 12px;
+}
+.app-shell .data-page-body .agents-catalog-section > .section-toolbar {
+  background: var(--surface);
+}
+.agents-catalog-section .section-toolbar .search-field {
+  flex: 0 1 420px;
+  width: min(420px, 100%);
+}
+.agents-catalog-section > .studio-data-table {
+  border: 0;
+  border-radius: 0 0 var(--radius-surface) var(--radius-surface);
+}
+.studio-data-table { border-radius: var(--radius-control); }
+.studio-data-table thead th {
+  color: var(--text-secondary);
+  background: var(--surface-sunken);
+  border-bottom-color: var(--border);
+  font-size: var(--font-size-caption);
+  height: 42px;
+}
+.studio-data-table tbody td { border-bottom-color: var(--border); }
+.studio-data-table tbody tr:hover,
+.studio-data-table tbody tr:focus-visible { background: var(--surface-sunken); }
+.app-shell .data-page-body > .section-toolbar,
+.app-shell .data-page-body .trace-toolbar,
+.app-shell .runtime-resource-section .section-toolbar {
+  background: var(--canvas);
+}
+.runtime-resource-section { margin-top: 24px; }
+.runtime-resource-group { border-radius: var(--radius-surface); }
+.studio-data-table :is(th, td):first-child { padding-left: 24px; }
+.studio-data-table :is(th, td):last-child { padding-right: 24px; }
+.empty-state {
+  border: 0;
+  background: transparent;
+  border-radius: 0;
+  gap: 12px;
+  padding: 48px 24px;
+  max-width: 480px;
+}
+.empty-state .empty-icon, .chat-empty-icon {
+  color: var(--text-secondary);
+  background: var(--surface-subtle);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+}
+.empty-state h2 { color: var(--text-primary); font-weight: var(--font-weight-medium); }
+.empty-state p { color: var(--text-secondary); line-height: 1.7; }
+.empty-state > div:has(> .button) {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+}
+.empty-state .primary-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 7px 15px;
+  min-height: var(--button-height);
+  font-size: var(--font-size-meta);
+}
+
+/* Authoring: make the form primary and the progress rail secondary. */
+.create-shell .create-rail { background: var(--canvas); }
+.create-shell .create-stage { border-radius: var(--radius-surface); }
+.create-shell .authoring-mode-tabs button,
+.create-shell .wizard-step,
+.create-shell .template-card { border-radius: var(--radius-control); }
+.create-shell .authoring-mode-tabs button.active,
+.create-shell .wizard-step.active {
+  border-color: transparent;
+  background: var(--selected);
+  color: var(--text-primary);
+}
+.create-shell .template-card.selected {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+}
+.create-shell .wizard-step.active .step-number,
+.create-shell .wizard-step.completed .step-number {
+  border-color: var(--button-primary-bg);
+  background: var(--button-primary-bg);
+  color: var(--button-primary-text);
+}
+.create-shell .wizard-actions,
+:root.dark .create-shell .wizard-actions {
+  background: var(--surface);
+  border-top-color: var(--border);
+  box-shadow: none;
+}
+.panel-heading p { color: var(--text-secondary); }
+
+/* Conversation: align the reading column and composer without extra chrome. */
+.studio-chat-shell { border-color: var(--border); border-radius: 0; }
+.chat-session-sidebar { background: var(--canvas); }
+.chat-session-header, .chat-session-search { background: transparent; }
+.chat-session-search { border-bottom: 0; }
+.chat-session-item { border-radius: var(--radius-control); }
+.chat-session-item.active {
+  border-color: transparent;
+  background: var(--selected);
+}
+.chat-conversation { border: 0; border-radius: 0; }
+.chat-conversation-header { border-bottom-color: var(--border); }
+.chat-message-list .message.user .message-content {
+  border: 0;
+  border-radius: 18px 18px 5px 18px;
+  padding: 12px 16px;
+}
+.chat-markdown { line-height: 1.8; }
+.chat-message-list .message.assistant .message-content { max-width: 760px; }
+.chat-message-list .message-meta { margin-bottom: 10px; }
+.chat-empty h2 { font-size: 24px; letter-spacing: -0.5px; }
+.chat-empty p { max-width: 400px; line-height: 1.75; }
+.chat-empty .suggestion-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 170px), 1fr));
+  gap: 10px;
+  width: 100%;
+  margin-top: 10px;
+}
+.chat-empty .suggestion-list button {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  border-radius: var(--radius-control);
+  padding: 14px;
+  line-height: 1.7;
+}
+.chat-composer-wrap { border-top: 0; padding-top: 16px; }
+.chat-composer {
+  border-radius: 18px;
+  background: var(--surface);
+  box-shadow: 0 4px 20px #2426220a, 0 1px 3px #24262208 !important;
+}
+.chat-composer:focus-within {
+  border-color: var(--accent);
+  box-shadow: var(--shadow-focus-subtle) !important;
+}
+.chat-composer textarea,
+.chat-composer textarea:hover,
+.chat-composer textarea:focus {
+  border-radius: 18px 18px 0 0;
+  padding: 16px 18px 8px;
+  font-size: var(--font-size-body);
+  line-height: 1.7;
+}
+.chat-composer-footer { padding: 4px 10px 10px 12px; }
+.chat-composer .chat-send-button { border-radius: 50%; }
+.chat-composer .chat-send-button:disabled {
+  background: var(--surface-hover);
+  color: var(--text-disabled);
+}
+.chat-code-block, .chat-activity-card { border-radius: var(--radius-control); }
+.chat-markdown pre code {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+}
+.chat-composer-disclaimer { font-size: var(--font-size-caption); }
+
+/* Keep established breakpoint behavior; only adjust spacing on small screens. */
+@media (max-width: 760px) {
+  .settings-section-nav {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background: var(--surface);
+    padding-block: 8px;
+    border-bottom: 1px solid var(--border);
+  }
+  .settings-group { scroll-margin-top: 64px; }
+}
+@media (min-width: 1024px) {
+  .chat-message-list { padding-inline: max(32px, calc(50% - 380px)); }
+  .chat-composer-wrap { padding-inline: max(24px, calc(50% - 396px)); }
+}
+@media (max-width: 720px) {
+  .navigation-rail .nav-group + .nav-group { margin-top: 10px; }
+  .navigation-rail .workspace-switcher { margin-block: 4px 8px; }
+  .navigation-rail .product { padding-inline: 0; }
+  .agents-catalog-header { padding-inline: 16px; }
+  .agents-catalog-section .section-toolbar { padding: 4px 16px 16px; }
+  .studio-data-table :is(th, td):first-child { padding-left: 16px; }
+  .studio-data-table :is(th, td):last-child { padding-right: 16px; }
+  .empty-state { padding: 32px 16px; }
+  .chat-empty { padding-inline: 8px; }
+  .chat-empty h2 { font-size: var(--font-size-section-title); }
+  .chat-composer textarea,
+  .chat-composer textarea:hover,
+  .chat-composer textarea:focus { font-size: 16px; padding-inline: 12px; }
+  .chat-composer-wrap { padding-top: 8px; }
+  .create-shell .create-stage { border-radius: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .chat-composer, .navigation-rail .nav-item { transition: none; }
+}

--- a/ksadk/studio/static/studio-refinement.css
+++ b/ksadk/studio/static/studio-refinement.css
@@ -5,136 +5,145 @@
  * Migrate these styles into the source theme before replacing the bundle.
  */
 
-/* Theme tokens, including aliases used by the compiled conversation UI. */
+/* King Design reference: https://design.ksyun.com/ and
+ * https://github.com/ksc-fe/kpc/blob/master/styles/theme.ts.
+ * Brand blue and neutral colors follow the official theme. Text-bearing blue
+ * controls use its palette(+1/+2/+3) shades to retain 4.5:1 white-text contrast.
+ * Dark surfaces adapt the same hue family to Studio's existing dark mode.
+ */
 :root {
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC",
     "Noto Sans CJK SC", "Microsoft YaHei UI", sans-serif;
   --font-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  --radius-control: 8px;
-  --radius-small: 6px;
-  --radius-surface: 12px;
-  --radius-block: 12px;
-  --radius-card: 12px;
-  --radius-inset: 8px;
-  --radius-chip: 6px;
-  --radius-rail: 8px;
+  --brand: #0091ea;
+  --radius-control: 4px;
+  --radius-small: 4px;
+  --radius-surface: 6px;
+  --radius-block: 6px;
+  --radius-card: 6px;
+  --radius-inset: 4px;
+  --radius-chip: 4px;
+  --radius-rail: 4px;
+  --radius-badge: 4px;
   --control-height: 40px;
   --button-height: 36px;
   --button-height-small: 32px;
 }
 
 :root:not(.dark) {
-  --canvas: #faf9f6;
-  --sidebar: #f2f1ed;
+  --canvas: #f3f5f6;
+  --sidebar: #ffffff;
   --surface: #ffffff;
   --surface-raised: #ffffff;
-  --surface-subtle: #f3f2ee;
-  --surface-sunken: #f6f5f1;
-  --surface-hover: #eeede7;
-  --hover: #eeede7;
-  --selected: #e7e8e0;
-  --text: #242622;
-  --text-primary: #242622;
-  --text-label: #41453b;
-  --text-secondary: #60635b;
-  --text-tertiary: #686d61;
-  --text-faint: #6b7064;
-  --text-disabled: #8a8d84;
-  --border: #e7e7df;
-  --border-card: #dedfd6;
-  --border-strong: #c9ccc1;
-  --accent: #505d43;
-  --accent-strong: #35432b;
-  --accent-soft: #eef0e8;
-  --accent-hover: #e5e9dc;
-  --accent-active: #dbe1d0;
-  --accent-border: #bfc8b1;
-  --button-primary-bg: #30342c;
-  --button-primary-bg-hover: #454d3c;
-  --button-primary-bg-active: #22271e;
+  --surface-subtle: #f3f5f6;
+  --surface-sunken: #f0f2f4;
+  --surface-hover: #edf0f2;
+  --hover: #edf0f2;
+  --selected: #e6f7ff;
+  --text: #3c4449;
+  --text-primary: #151b1e;
+  --text-label: #3c4449;
+  --text-secondary: #59656d;
+  --text-tertiary: #626e76;
+  --text-faint: #626e76;
+  --text-disabled: #848f9a;
+  --border: #e4e8eb;
+  --border-card: #e0e5e8;
+  --border-strong: #d0d5d9;
+  --accent: #0063a8;
+  --accent-strong: #004d87;
+  --accent-soft: #e6f7ff;
+  --accent-hover: #d5effd;
+  --accent-active: #bfe5fa;
+  --accent-border: #a9dffa;
+  --focus-ring: var(--brand);
+  --button-primary-bg: #0079c9;
+  --button-primary-bg-hover: #0063a8;
+  --button-primary-bg-active: #004d87;
   --button-primary-text: #ffffff;
-  --success: #347354;
-  --success-soft: #edf5ee;
-  --info: #456982;
-  --info-soft: #eff4f7;
-  --warning: #8a631e;
-  --warning-text: #765214;
-  --warning-soft: #fbf4e5;
-  --danger: #b23e35;
-  --danger-soft: #fdf0ed;
+  --success: #09791a;
+  --success-soft: #e6ffe6;
+  --info: var(--accent);
+  --info-soft: var(--accent-soft);
+  --warning: #8c5b01;
+  --warning-text: #8c5b01;
+  --warning-soft: #fff3e6;
+  --danger: #b32512;
+  --danger-soft: #ffe6e6;
   --edge: var(--success);
   --edge-soft: var(--success-soft);
-  --edge-border: #c9dfd0;
+  --edge-border: #b1ecb4;
   --cloud: var(--info);
   --cloud-soft: var(--info-soft);
-  --cloud-border: #d0dce5;
+  --cloud-border: var(--accent-border);
   --route: var(--warning);
   --route-soft: var(--warning-soft);
-  --code-bg: #f5f5f0;
-  --code-text: #353b31;
-  --code-token-comment: #707667;
-  --shadow-overlay: 0 16px 48px #2426221c, 0 2px 8px #2426220a;
-  --shadow-focus: 0 0 0 3px #505d4326;
-  --shadow-focus-subtle: 0 0 0 3px #505d4318;
-  --shadow-control: 0 1px 2px #24262208;
-  --shadow-toast: 0 8px 28px #2426221a;
+  --code-bg: #f3f5f6;
+  --code-text: #3c4449;
+  --code-token-comment: #626e76;
+  --shadow-overlay: 0 4px 32px 4px #00000014;
+  --shadow-focus: 0 0 0 3px #0091ea26;
+  --shadow-focus-subtle: 0 0 0 3px #0091ea18;
+  --shadow-control: 0 1px 2px #151b1e0a;
+  --shadow-toast: 0 2px 16px 2px #00000014;
 }
 
 :root.dark {
-  --canvas: #1b1c1b;
-  --sidebar: #171817;
-  --surface: #222322;
-  --surface-raised: #292b28;
-  --surface-subtle: #2b2c2a;
-  --surface-sunken: #1e201d;
-  --surface-hover: #33362f;
-  --hover: #33362f;
-  --selected: #383d31;
-  --text: #eeefeb;
-  --text-primary: #eeefeb;
-  --text-label: #daddd3;
-  --text-secondary: #bec1b7;
-  --text-tertiary: #a0a598;
-  --text-faint: #92998a;
-  --text-disabled: #73796c;
-  --border: #363932;
-  --border-card: #3b3f35;
-  --border-strong: #545b4b;
-  --accent: #b8c7a5;
-  --accent-strong: #d2dfc1;
-  --accent-soft: #30372a;
-  --accent-hover: #3a4432;
-  --accent-active: #46523d;
-  --accent-border: #596b47;
-  --button-primary-bg: #e3e6dc;
-  --button-primary-bg-hover: #f2f4eb;
-  --button-primary-bg-active: #ccd4c0;
-  --button-primary-text: #242b1e;
-  --success: #95c5a2;
-  --success-soft: #26392b;
-  --info: #a6bed0;
-  --info-soft: #29353d;
-  --warning: #dfbb78;
-  --warning-text: #ecd099;
-  --warning-soft: #3c3323;
-  --danger: #e7a096;
-  --danger-soft: #432c28;
+  --canvas: #151b1e;
+  --sidebar: #1b2226;
+  --surface: #22292d;
+  --surface-raised: #293237;
+  --surface-subtle: #2a3338;
+  --surface-sunken: #1b2226;
+  --surface-hover: #343e43;
+  --hover: #343e43;
+  --selected: #173b50;
+  --text: #e6eaed;
+  --text-primary: #f3f5f6;
+  --text-label: #d0d5d9;
+  --text-secondary: #bec3c5;
+  --text-tertiary: #a6afb5;
+  --text-faint: #a6afb5;
+  --text-disabled: #737f87;
+  --border: #343e43;
+  --border-card: #3b464c;
+  --border-strong: #526169;
+  --accent: #6ec6f4;
+  --accent-strong: #a9dffa;
+  --accent-soft: #173b50;
+  --accent-hover: #1e4b63;
+  --accent-active: #265c77;
+  --accent-border: #316682;
+  --focus-ring: #ffffff;
+  --button-primary-bg: #0079c9;
+  --button-primary-bg-hover: #0063a8;
+  --button-primary-bg-active: #004d87;
+  --button-primary-text: #ffffff;
+  --success: #82d988;
+  --success-soft: #203a2a;
+  --info: var(--accent);
+  --info-soft: var(--accent-soft);
+  --warning: #ffc375;
+  --warning-text: #ffc375;
+  --warning-soft: #403323;
+  --danger: #ff928c;
+  --danger-soft: #482a2c;
   --edge: var(--success);
   --edge-soft: var(--success-soft);
-  --edge-border: #425a44;
+  --edge-border: #355b40;
   --cloud: var(--info);
   --cloud-soft: var(--info-soft);
-  --cloud-border: #475b68;
+  --cloud-border: var(--accent-border);
   --route: var(--warning);
   --route-soft: var(--warning-soft);
-  --code-bg: #1d201b;
-  --code-text: #e0e4d8;
-  --code-token-comment: #9ba68e;
-  --shadow-overlay: 0 16px 48px #0000004d, 0 2px 8px #00000026;
-  --shadow-focus: 0 0 0 3px #b8c7a52e;
-  --shadow-focus-subtle: 0 0 0 3px #b8c7a51a;
+  --code-bg: #1b2226;
+  --code-text: #d0d5d9;
+  --code-token-comment: #a6afb5;
+  --shadow-overlay: 0 4px 32px 4px #0000004d;
+  --shadow-focus: 0 0 0 3px #6ec6f42e;
+  --shadow-focus-subtle: 0 0 0 3px #6ec6f41a;
   --shadow-control: 0 1px 2px #00000026;
-  --shadow-toast: 0 8px 28px #00000040;
+  --shadow-toast: 0 2px 16px 2px #00000040;
 }
 
 :root:not(.dark), :root.dark {
@@ -144,8 +153,8 @@
   --danger-deep: var(--danger);
   --kc-accent-border: var(--accent-border);
   --kc-accent-fill: var(--accent-soft);
-  --kc-accent-fill-strong: var(--surface-subtle);
-  --kc-user-bubble: var(--surface-subtle);
+  --kc-accent-fill-strong: var(--accent-soft);
+  --kc-user-bubble: var(--accent-soft);
   --kc-user-bubble-border: transparent;
   --kc-think-border: var(--border);
   --kc-think-fill: var(--surface-sunken);
@@ -160,16 +169,16 @@
   --kc-rail-fill: var(--canvas);
 }
 
-/* Quiet navigation with a consistent selected state. */
+/* King Design navigation: neutral surfaces with blue selection. */
 .navigation-rail .product {
   border-bottom-color: transparent;
   padding-inline: 10px;
 }
 .navigation-rail .product-mark {
   color: var(--button-primary-text);
-  background: var(--button-primary-bg);
+  background: var(--brand);
   border-color: transparent;
-  border-radius: 9px;
+  border-radius: var(--radius-surface);
   box-shadow: none;
 }
 .navigation-rail .product-copy { gap: 3px; }
@@ -205,11 +214,11 @@
 }
 .navigation-rail .nav-item svg { stroke-width: 1.7; }
 .navigation-rail .nav-item.active {
-  color: var(--text-primary);
+  color: var(--accent);
   background: var(--selected);
   font-weight: var(--font-weight-semibold);
 }
-.navigation-rail .nav-item.active svg { color: var(--text-primary); }
+.navigation-rail .nav-item.active svg { color: var(--accent); }
 .navigation-rail .nav-item.active::before { content: none; }
 .navigation-rail .sidebar-footer,
 :root.dark .navigation-rail .sidebar-footer {
@@ -223,7 +232,7 @@
 }
 .global-header,
 :root.dark .global-header {
-  background: var(--canvas);
+  background: var(--surface);
   border-bottom-color: var(--border);
   backdrop-filter: none;
 }
@@ -248,9 +257,9 @@ input, textarea, select, .studio-select-trigger, .studio-multi-select-trigger,
 .button:not(.accent):not(.tertiary):hover:not(:disabled),
 .button.secondary:hover:not(:disabled),
 .icon-button.secondary:hover:not(:disabled) {
-  border-color: var(--border-strong);
-  color: var(--text);
-  background: var(--surface-hover);
+  border-color: var(--brand);
+  color: var(--accent);
+  background: var(--surface);
 }
 /* The public bundle's generic button rule also matches destructive actions. */
 .button.danger, .button.subtle-danger {
@@ -264,14 +273,23 @@ input, textarea, select, .studio-select-trigger, .studio-multi-select-trigger,
   border-color: var(--danger);
 }
 .button:disabled, .icon-button:disabled { opacity: 0.55; }
+.studio-select-trigger, .studio-multi-select-trigger {
+  background: var(--surface);
+  outline: none;
+}
+.studio-select-trigger:hover:not(:disabled),
+.studio-multi-select-trigger:hover:not(:disabled) {
+  background: var(--surface);
+  border-color: var(--brand);
+}
 .app-shell :is(button, a, [role="tab"], [role="combobox"]):focus-visible,
 .overlay :is(button, a, [role="tab"], [role="combobox"]):focus-visible {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--focus-ring);
   outline-offset: 3px;
 }
 :is(input, textarea, select):focus,
 .search-field:focus-within {
-  outline: 2px solid var(--accent-border);
+  outline: 2px solid var(--focus-ring);
   outline-offset: 1px;
   border-color: var(--accent);
 }
@@ -284,18 +302,53 @@ input, textarea, select, .studio-select-trigger, .studio-multi-select-trigger,
 .studio-select-trigger:focus-visible,
 .studio-multi-select-trigger:focus-visible {
   border-color: var(--accent);
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--focus-ring);
   outline-offset: 3px;
 }
 .search-field input:focus { outline: none; }
 input::placeholder, textarea::placeholder { color: var(--text-tertiary); opacity: 1; }
-.page-tabs, .segmented-control { background: var(--surface-subtle); }
-.page-tabs button, .segmented-control button { border-radius: 6px; }
-.page-tabs button.active, .page-tabs button[aria-selected="true"],
+/* Page navigation uses a blue underline; view toggles remain segmented. */
+.page-tabs {
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--border-strong);
+  border-radius: 0;
+  padding: 0;
+  gap: 24px;
+}
+.page-tabs button {
+  min-height: 40px;
+  padding-inline: 4px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+}
+.page-tabs button:hover:not(:disabled),
+.page-tabs button.active, .page-tabs button[aria-selected="true"] {
+  background: transparent;
+  color: var(--accent);
+  box-shadow: none;
+}
+.page-tabs button.active, .page-tabs button[aria-selected="true"] {
+  border-bottom-color: var(--brand);
+}
+.page-tabs button .n {
+  display: inline-block;
+  min-width: 18px;
+  margin-left: 6px;
+  padding-inline: 4px;
+  border-radius: var(--radius-small);
+  background: var(--surface-subtle);
+  font-size: var(--font-size-caption);
+  line-height: 18px;
+}
+.page-tabs button[aria-selected="true"] .n { background: var(--accent-soft); }
+.segmented-control { background: var(--surface-subtle); }
+.segmented-control button { border-radius: var(--radius-control); }
 .segmented-control button.selected, .segmented-control button[aria-selected="true"] {
-  border-color: var(--border);
+  border-color: var(--accent-border);
   background: var(--surface);
-  color: var(--text-primary);
+  color: var(--accent);
   box-shadow: var(--shadow-control);
 }
 :is(.block:not(.runtime-resource-group), .table-section, .trace-list-page,
@@ -329,6 +382,16 @@ input::placeholder, textarea::placeholder { color: var(--text-tertiary); opacity
   min-height: 40px;
   padding-inline: 12px;
 }
+.more-actions-item, .composer-action-item, .chat-model-option,
+.chat-approval-option, .composer-command-menu [cmdk-item] {
+  border-radius: var(--radius-control);
+}
+.chat-model-option[data-highlighted] { background: var(--surface-hover); }
+.chat-model-option[data-state="checked"],
+.chat-approval-option:not(.full)[data-state="checked"] {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
 .studio-select-item + .studio-select-item,
 .more-actions-item + .more-actions-item,
 .composer-action-item + .composer-action-item,
@@ -340,12 +403,12 @@ input::placeholder, textarea::placeholder { color: var(--text-tertiary); opacity
 .studio-select-item:focus-visible, .more-actions-item:focus-visible,
 .composer-action-item:focus-visible, .chat-model-option:focus-visible,
 .chat-approval-option:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--focus-ring);
   outline-offset: -2px;
 }
 .studio-dialog, .overlay .drawer {
   border-color: var(--border);
-  border-radius: 16px;
+  border-radius: var(--radius-surface);
   box-shadow: var(--shadow-overlay) !important;
 }
 .appearance-option { border-radius: var(--radius-control); }
@@ -410,7 +473,7 @@ input::placeholder, textarea::placeholder { color: var(--text-tertiary); opacity
   color: var(--text-secondary);
   background: var(--surface-subtle);
   border: 1px solid var(--border);
-  border-radius: 14px;
+  border-radius: var(--radius-surface);
 }
 .empty-state h2 { color: var(--text-primary); font-weight: var(--font-weight-medium); }
 .empty-state p { color: var(--text-secondary); line-height: 1.7; }
@@ -439,7 +502,7 @@ input::placeholder, textarea::placeholder { color: var(--text-tertiary); opacity
 .create-shell .wizard-step.active {
   border-color: transparent;
   background: var(--selected);
-  color: var(--text-primary);
+  color: var(--accent);
 }
 .create-shell .template-card.selected {
   border-color: var(--accent-border);
@@ -473,7 +536,7 @@ input::placeholder, textarea::placeholder { color: var(--text-tertiary); opacity
 .chat-conversation-header { border-bottom-color: var(--border); }
 .chat-message-list .message.user .message-content {
   border: 0;
-  border-radius: 18px 18px 5px 18px;
+  border-radius: 12px 12px 4px 12px;
   padding: 12px 16px;
 }
 .chat-markdown { line-height: 1.8; }
@@ -497,9 +560,9 @@ input::placeholder, textarea::placeholder { color: var(--text-tertiary); opacity
 }
 .chat-composer-wrap { border-top: 0; padding-top: 16px; }
 .chat-composer {
-  border-radius: 18px;
+  border-radius: 12px;
   background: var(--surface);
-  box-shadow: 0 4px 20px #2426220a, 0 1px 3px #24262208 !important;
+  box-shadow: var(--shadow-control) !important;
 }
 .chat-composer:focus-within {
   border-color: var(--accent);
@@ -508,13 +571,14 @@ input::placeholder, textarea::placeholder { color: var(--text-tertiary); opacity
 .chat-composer textarea,
 .chat-composer textarea:hover,
 .chat-composer textarea:focus {
-  border-radius: 18px 18px 0 0;
+  border-radius: 12px 12px 0 0;
   padding: 16px 18px 8px;
   font-size: var(--font-size-body);
   line-height: 1.7;
 }
 .chat-composer-footer { padding: 4px 10px 10px 12px; }
 .chat-composer .chat-send-button { border-radius: 50%; }
+.chat-composer .chat-send-button:hover:not(:disabled) { opacity: 1; }
 .chat-composer .chat-send-button:disabled {
   background: var(--surface-hover);
   color: var(--text-disabled);

--- a/tests/studio/e2e/studio_visual_review.py
+++ b/tests/studio/e2e/studio_visual_review.py
@@ -109,7 +109,10 @@ def main() -> None:
                             assert (
                                 main and main["x"] >= 0 and main["x"] + main["width"] <= width + 1
                             )
-                            page.screenshot(path=str(args.output / f"{theme}-{width}-{name}.png"))
+                            page.screenshot(
+                                path=str(args.output / f"{theme}-{width}-{name}.png"),
+                                animations="disabled",
+                            )
                             checks.append({"theme": theme, "width": width, "page": name})
 
                         for label, name in PAGES:
@@ -123,6 +126,35 @@ def main() -> None:
                                 page.get_by_role("textbox", name="消息").fill("检查窄屏输入与焦点")
                                 expect(page.get_by_role("button", name="发送消息")).to_be_enabled()
                             capture(name)
+                            if name == "agents":
+                                assert_readable(
+                                    page, ".agent-cell-copy strong, .agent-cell-copy > span"
+                                )
+                                trigger = page.get_by_role("combobox", name="筛选 Agent 状态")
+                                trigger.click()
+                                expect(page.locator(".studio-select-content")).to_be_in_viewport(
+                                    ratio=1
+                                )
+                                expect(page.locator(".studio-select-item").first).to_be_focused()
+                                page.keyboard.press("ArrowDown")
+                                expect(page.locator(".studio-select-item").nth(1)).to_be_focused()
+                                page.locator(".studio-select-item").nth(1).hover()
+                                capture("agents-filter")
+                                rows = page.locator(".studio-select-item").all()
+                                assert len(rows) >= 2
+                                boxes = [row.bounding_box() for row in rows]
+                                for index, box in enumerate(boxes):
+                                    assert box and box["height"] >= 40
+                                    assert box["x"] >= 0 and box["y"] >= 0, box
+                                    assert box["x"] + box["width"] <= width, box
+                                    assert box["y"] + box["height"] <= height, box
+                                    if index:
+                                        previous = boxes[index - 1]
+                                        assert previous
+                                        assert box["y"] - previous["y"] - previous["height"] >= 6
+                                assert_readable(page, ".studio-select-item")
+                                page.keyboard.press("Escape")
+                                expect(trigger).to_be_focused()
                         page.locator(".primary-nav").get_by_role(
                             "button", name="工程资源", exact=True
                         ).click()

--- a/tests/studio/e2e/studio_visual_review.py
+++ b/tests/studio/e2e/studio_visual_review.py
@@ -1,0 +1,157 @@
+"""Visual acceptance of the public Studio bundle (no editable UI source needed).
+
+Run with uv run python tests/studio/e2e/studio_visual_review.py --output /tmp/studio-visual
+Optionally pass --channel chromium to use Playwright's full Chromium build.
+Screenshots are review artifacts, not pixel snapshots tied to an OS font stack.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from playwright.sync_api import Page, expect, sync_playwright
+from studio_e2e_support import studio_server
+from studio_responsive_smoke import assert_no_root_overflow, create_test_agent
+
+PAGES = (
+    ("Agent", "agents"),
+    ("会话", "conversations"),
+    ("工程资源", "resources"),
+    ("运行资源", "runtime"),
+    ("插件", "plugins"),
+    ("构建", "builds"),
+    ("部署", "deployments"),
+    ("自动化", "automations"),
+    ("编排", "orchestration"),
+    ("可观测", "traces"),
+    ("评测", "evaluations"),
+)
+VIEWPORTS = ((390, 844), (768, 768), (1024, 768), (1440, 960), (1920, 1080))
+
+
+def assert_readable(page: Page, selector: str) -> None:
+    """Measure actual rendered text/background pairs, including inherited fill."""
+    pairs = page.locator(selector).evaluate_all(
+        r"""elements => elements.filter(e => e.getClientRects().length).map(e => {
+          const rgb = value => {
+            const match = value.match(/^rgba?\(([^)]+)\)$/);
+            if (!match) throw new Error(`Unsupported color: ${value}`);
+            return match[1].split(',').map(Number);
+          };
+          let background = [255, 255, 255];
+          for (let parent = e; parent; parent = parent.parentElement) {
+            const color = rgb(getComputedStyle(parent).backgroundColor);
+            if (color.length === 3 || color[3] === 1) {
+              background = color.slice(0, 3); break;
+            }
+            if (color[3] !== 0) throw new Error('Translucent text surface needs compositing');
+          }
+          return {text: e.textContent.trim().slice(0, 50),
+            foreground: rgb(getComputedStyle(e).color).slice(0, 3), background};
+        })"""
+    )
+    assert pairs, f"No visible text matched {selector}"
+
+    def luminance(rgb: list[float]) -> float:
+        values = [value / 255 for value in rgb]
+        values = [v / 12.92 if v <= 0.04045 else ((v + 0.055) / 1.055) ** 2.4 for v in values]
+        return sum(v * weight for v, weight in zip(values, (0.2126, 0.7152, 0.0722)))
+
+    for pair in pairs:
+        a, b = luminance(pair["foreground"]), luminance(pair["background"])
+        ratio = (max(a, b) + 0.05) / (min(a, b) + 0.05)
+        assert ratio >= 4.5, {"contrast": ratio, **pair}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--channel", default=None)
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=True)
+    checks: list[dict] = []
+    with TemporaryDirectory(prefix="studio-visual-") as tmp, studio_server(Path(tmp)) as url:
+        create_test_agent(url)
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch(channel=args.channel)
+            try:
+                for theme in ("light", "dark"):
+                    for width, height in VIEWPORTS:
+                        context = browser.new_context(
+                            viewport={"width": width, "height": height},
+                            color_scheme=theme,
+                            reduced_motion="reduce",
+                            device_scale_factor=1,
+                        )
+                        context.add_init_script(
+                            f"localStorage.setItem('agentkit-studio-theme', {json.dumps(theme)})"
+                        )
+                        page = context.new_page()
+                        errors: list[str] = []
+                        page.on("pageerror", lambda error: errors.append(str(error)))
+                        page.goto(url, wait_until="domcontentloaded")
+                        expect(page.locator(".app-shell")).to_be_visible()
+                        expect(page.locator("html")).to_have_attribute("data-theme", theme)
+                        expect(
+                            page.get_by_role("button", name="创建 Agent", exact=True).first
+                        ).to_be_enabled()
+                        assert_readable(page, ".button.accent:not(:disabled)")
+                        assert_readable(page, ".navigation-rail .nav-item")
+                        if width >= 1024:
+                            assert_readable(page, ".navigation-rail .nav-label")
+
+                        def capture(name: str) -> None:
+                            assert_no_root_overflow(page)
+                            main = page.locator(".app-main").bounding_box()
+                            assert (
+                                main and main["x"] >= 0 and main["x"] + main["width"] <= width + 1
+                            )
+                            page.screenshot(path=str(args.output / f"{theme}-{width}-{name}.png"))
+                            checks.append({"theme": theme, "width": width, "page": name})
+
+                        for label, name in PAGES:
+                            page.locator(".primary-nav").get_by_role(
+                                "button", name=label, exact=True
+                            ).click()
+                            if name == "conversations":
+                                expect(page.locator(".chat-composer")).to_be_visible()
+                                composer = page.locator(".chat-composer").bounding_box()
+                                assert composer and composer["y"] + composer["height"] <= height
+                                page.get_by_role("textbox", name="消息").fill("检查窄屏输入与焦点")
+                                expect(page.get_by_role("button", name="发送消息")).to_be_enabled()
+                            capture(name)
+                        page.locator(".primary-nav").get_by_role(
+                            "button", name="工程资源", exact=True
+                        ).click()
+                        for resource in ("模型", "Tool", "MCP", "Skill"):
+                            page.get_by_role("tab").filter(has_text=resource).click()
+                            capture(f"resources-{resource}")
+                        page.locator(".primary-nav").get_by_role(
+                            "button", name="Agent", exact=True
+                        ).click()
+                        page.get_by_role("button", name="创建 Agent", exact=True).first.click()
+                        capture("create")
+                        page.get_by_role("button", name="设置", exact=True).click()
+                        dialog = page.get_by_role("dialog", name="设置")
+                        expect(dialog).to_be_visible()
+                        capture("settings")
+                        page.keyboard.press("Escape")
+                        expect(dialog).to_be_hidden()
+                        expect(page.get_by_role("button", name="设置", exact=True)).to_be_focused()
+                        assert not errors, errors
+                        context.close()
+                        print(f"PASS {theme} {width}×{height}", flush=True)
+            finally:
+                browser.close()
+    (args.output / "results.json").write_text(json.dumps(checks, ensure_ascii=False, indent=2))
+    print(
+        f"PASS {len(checks)} page/theme/viewport captures; "
+        "contrast, composer, focus, no page errors"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Studio 的导航、列表、表单与会话存在过多嵌套边框，组件状态和留白也不一致。本次按金山云 King Design 统一蓝色、中性灰、圆角与组件层级，让主按钮、导航选中、标签页和菜单使用一致的视觉语言。

- 基于 [King Design 色彩规范](https://design.ksyun.com/docs/design/guide-9/) 和 [官方主题参数](https://github.com/ksc-fe/kpc/blob/master/styles/theme.ts)，采用品牌蓝 `#0091EA`、浅灰画布、白色面板与 4–6px 控件 / 面板圆角，并适配 Studio 深色模式。
- 文字主按钮采用官方蓝色色阶 `#0079C9`，白字对比度为 4.59:1；悬停和按下使用更深的同系蓝色。导航与选项使用淡蓝选中底色，页面标签采用蓝色下划线并分离计数间距。
- 统一列表、筛选、创建表单、设置弹层和会话阅读区域；改善窄屏设置导航、代码块和输入工具栏样式。
- 下拉筛选、多选、更多操作和会话菜单增加 6px 选项间距与内部留白；悬停、选中及键盘高亮使用底色反馈，移除选项高亮描边。选择框悬停 / 展开也保留中性边界，不出现彩色外框。
- 新增独立的 `studio-refinement.css`，由生产静态入口加载；视觉验收脚本覆盖 180 个页面 / 主题 / 屏宽组合。

## Validation

主题调整已执行以下检查。选项描边调整后，再次通过 180 项视觉矩阵和 public-audit，并在真实资源菜单确认选中与键盘高亮项均无 outline、border 或 box-shadow，只有底色反馈：

- [x] `uv run --no-sync python tests/studio/e2e/studio_browser_smoke.py`
- [x] `uv run --no-sync python tests/studio/e2e/studio_responsive_smoke.py`
- [x] `PYTHONPATH=. uv run --no-sync python tests/studio/e2e/conversation_items_browser_e2e.py`
- [x] `uv run --no-sync python tests/studio/e2e/studio_visual_review.py --output /tmp/studio-fill-only-menus`：18 个状态 × 2 种主题 × 5 种屏宽（390 / 768 / 1024 / 1440 / 1920px），180 项通过。
- [x] 视觉矩阵检查横向溢出、输入区和发送按钮、页面脚本错误、对话框退出与焦点返回，以及主按钮、导航、Agent 名称 / 副标题和菜单文字的 4.5:1 对比度。
- [x] 菜单验证覆盖键盘下一项、鼠标悬停、至少 6px 行间隔、40px 最小行高、屏幕边界和 Escape 后焦点恢复；截图在动画结束状态采集。
- [x] 真实浏览器补充检查 Agent、工程资源标签、设置、深浅主题切换、筛选与模型子菜单，以及已有多轮会话的文本、表格和代码块。
- [x] `uv run --no-sync pytest -q tests/test_runtime_common_packaging.py -k 'release_build_generates_ignored_react_studio_static_assets or package_data'`：2 passed。
- [x] Ruff check / format check、`git diff --cached --check`。
- [x] `uv run --no-sync make build-studio-static`：公开 main 复用生产 bundle，本项为静态入口与资源校验。
- [x] `uv run --no-sync make public-audit`：凭据与公开路径审计通过，0 violations。

`uv run --no-sync make public-preflight` 已重新执行，但停在版本门禁：本地 0.8.3 与 PyPI 已发布的 0.8.3 相同。完整发布预检未通过；版本号保持原值，未绕过门禁。全量 pytest、文档站构建及完整 wheel/sdist 发布检查未在本轮本地执行。

浏览器验证环境没有可用的 DSH capability host，相应页面覆盖不可用状态；本轮会话 E2E 使用测试 fixture，真实浏览器检查已有聊天记录，没有重新调用收费模型 API。上述结果不表示云端部署或插件宿主业务联通。

Flatwork 的 layoutTabs 页面本次返回 502，浏览器加载也受阻；标签样式以可访问的 King Design 官方 Tabs 为参考。深色模式是依据同一色系对 Studio 的适配。

## Visual review follow-up

2026-09-07 对当前提交 `aa43d38` 重新执行 Studio browser smoke、responsive smoke、canonical conversation browser E2E 与 180 个页面/主题/屏宽的视觉矩阵，既有断言均通过。另完成 52 个组件状态的截图和样式复核；截图数量不代表独立业务链路数量，也不代表全部视觉问题已解决。

专项复核发现以下尚未修复的问题，需在后续前端组件工作中处理：

- 设置弹窗打开并稳定后会自动滚动，标题和关闭按钮移出可视区；浅深主题及桌面/窄屏均可复现。
- canonical runtime 测试场景中，后台状态为 `WAITING_INPUT` 且无错误，前端同时显示运行失败与等待确认；审批后仍能继续进入结构化输入。该发现限定于已复现的测试路径，未推断所有真实模型都会触发。
- 窄屏 Agent 行更多操作按钮本体会压缩，普通输入和动态表单仍存在焦点样式、多层边框及按钮颜色不一致。

这些问题未被现有通用断言覆盖。本 PR 包含的是已实现的共享样式改进；导航重组、会话详情收纳和三套设计提案尚未实施，本地评审与提案材料未纳入公开候选。

## Public Surface

- [x] 用户可见变化限于 Studio 外观，无新增配置或操作流程，文档站与 GitHub Pages 无改动。
- [x] CSS 随现有 Studio package data 分发；版本、依赖、extras 与发布配置无改动。
- [x] 本地设计评审与截图材料未纳入公开候选。

维护说明：公开 main 不含可编辑的 Studio React 源码，本次样式依赖当前 bundle 的语义 token 和组件类名。未来替换 bundle 前，应将样式迁入源主题并重新运行视觉验收。

## Security impact

- [x] 未引入凭据、私有地址、真实用户数据或环境配置文件。
- [x] 无鉴权、权限、协议或运行时逻辑变更。

## Release

- [x] 本次为 UI 样式改进，未改版本号或 CHANGELOG 发版条目。
- [x] 未执行发布或部署；正式发布仍需维护者评审及发布门禁。
- [x] 未修改分支保护或发布环境保护。

