### PR TITLE
fix(events): use one durable authority behind resilient sessions

### DIFF
--- a/ksadk/events/canonical_store.py
+++ b/ksadk/events/canonical_store.py
@@ -158,7 +158,9 @@ class RuntimeEventStore:
             self._typed_session_id = session_id
         else:
             self._event_store = None
-            self._service = store
+            # A live-first session wrapper may expose one durable authority for
+            # canonical facts without claiming that its dual writes are atomic.
+            self._service = getattr(store, "canonical_event_service", store)
             self._typed_session_id = session_id
 
     @property

--- a/ksadk/sessions/resilient.py
+++ b/ksadk/sessions/resilient.py
@@ -50,23 +50,24 @@ class ResilientSessionService(BaseSessionService):
         ] = ContextVar(f"checkpoint_partition_{id(self)}", default=None)
         self._probe_task: asyncio.Task[None] | None = None
 
-    # 委托 primary 的 storage_capabilities——ResilientSessionService 只是容错包装层，
-    # 实际存储能力由 primary 决定（PostgresSessionService / LocalSessionService 都设了
-    # CANONICAL_EVENT_STORAGE_CAPABILITIES）。不委托会继承 BaseSessionService 的空默认，
-    # 导致 _require_storage_capabilities 误报"backend must support atomic seq..."。
     @property
-    def storage_capabilities(self) -> Any:
-        return self.primary.storage_capabilities
+    def canonical_event_service(self) -> BaseSessionService:
+        """Return the single durable authority for canonical runtime facts.
+
+        Legacy session state remains live-first. Canonical event sequences cannot
+        fail over to the independently sequenced fallback without splitting one
+        logical log, so RuntimeEventStore binds directly to the primary service.
+        """
+
+        return self.primary
 
     @property
     def degraded(self) -> bool:
         return not self._primary_enabled
 
     # This service is intentionally live-first and writes two independently
-    # sequenced stores.  Even when both children can atomically bind a local
-    # seq, the wrapper cannot guarantee one shared physical seq/fact across
-    # both writes, so it inherits BaseSessionService's empty canonical storage
-    # capabilities and RuntimeEventStore fails closed before either write.
+    # sequenced stores, so the wrapper itself does not claim canonical storage
+    # capabilities.
 
     async def _call_primary(self, method_name: str, *args: Any, **kwargs: Any) -> tuple[bool, Any]:
         if not self._primary_enabled:

--- a/tests/test_resilient_canonical_authority.py
+++ b/tests/test_resilient_canonical_authority.py
@@ -1,0 +1,33 @@
+import pytest
+
+from ksadk.events.canonical import RunStarted, SourceRef
+from ksadk.events.canonical_store import RuntimeEventStore, canonical_storage_id
+from ksadk.sessions.in_memory import InMemorySessionService
+from ksadk.sessions.resilient import ResilientSessionService
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_runtime_events_use_resilient_primary_as_single_authority() -> None:
+    primary = InMemorySessionService()
+    fallback = InMemorySessionService()
+    service = ResilientSessionService(primary, fallback=fallback)
+    await service.create_session("agent-1", "user-1", session_id="session-1")
+    event = RunStarted(
+        schema_version=2,
+        event_id="event-1",
+        seq=0,
+        timestamp=1.0,
+        run_id="run-1",
+        scope_id="scope-1",
+        source=SourceRef(framework="adk", native_event_id="native-1"),
+        status="running",
+    )
+
+    persisted = await RuntimeEventStore(service).append_one("session-1", event)
+
+    assert persisted.seq == 1
+    assert [stored.id for stored in await primary.get_events("session-1")] == [
+        canonical_storage_id("session-1", "event-1")
+    ]
+    assert await fallback.get_events("session-1") == []


### PR DESCRIPTION
PR #68 correctly identified that canonical runtime-event persistence must see the PostgreSQL backend's capabilities, but forwarding those capabilities through the live-first resilient wrapper also made its independently sequenced primary and fallback writes appear atomic.

This follow-up gives `RuntimeEventStore` an explicit single durable authority while keeping legacy session state on the resilient wrapper. Canonical events now write only to the primary store, so sequence allocation and idempotency stay within one physical log; a regression test verifies that the fallback receives no duplicate canonical fact.

Validation:
- `uv run pytest -q tests/test_resilient_canonical_authority.py` (1 passed)
- `uv run ruff check ksadk/events/canonical_store.py ksadk/sessions/resilient.py tests/test_resilient_canonical_authority.py`
- `git diff --check`

The original contributor's commit remains intact in main through PR #68.
